### PR TITLE
Fix typo in uboot var name

### DIFF
--- a/fwup.conf
+++ b/fwup.conf
@@ -210,7 +210,7 @@ task upgrade.a {
 
       # Clear some firmware information just in case this update gets
       # interrupted midway.
-      uboot_unsetenv(uboot-env, "nerves_fw_a_version")
+      uboot_unsetenv(uboot-env, "a.nerves_fw_version")
       # Reset the previous contents of the A boot partition
       fat_mkfs(${BOOT_A_PART_OFFSET}, ${BOOT_A_PART_COUNT})
       fat_setlabel(${BOOT_A_PART_OFFSET}, "BOOT-A")
@@ -258,7 +258,7 @@ task upgrade.b {
 
       # Clear some firmware information just in case this update gets
       # interrupted midway.
-      uboot_unsetenv(uboot-env, "nerves_fw_b_version")
+      uboot_unsetenv(uboot-env, "b.nerves_fw_version")
 
       # Reset the previous contents of the B boot partition
       fat_mkfs(${BOOT_B_PART_OFFSET}, ${BOOT_B_PART_COUNT})


### PR DESCRIPTION
I just noticed this typo. I doubt that anyone will notice, but if a firmware update fails midway and messes up a partition, the version number metadata will be missing. That was the original intention so that if you inspected a system, you could tell whether reverting to the other partition would even have a chance of working.